### PR TITLE
Fix fopen mode

### DIFF
--- a/src/Sephpa.php
+++ b/src/Sephpa.php
@@ -173,7 +173,7 @@ abstract class Sephpa
      */
     public function storeSepaFile($filename = 'payments.xml', $creDtTm = '')
     {
-        $file = fopen($filename, 'b');
+        $file = fopen($filename, 'wb');
         fwrite($file, $this->generateXml($creDtTm));
         fclose($file);
     }


### PR DESCRIPTION
`b` is invalid, must be `wb`, `rb`, `ab`, ... etc