### PR TITLE
Fix decimal mark by using F as type specifier in sprintf()

### DIFF
--- a/src/Sephpa.php
+++ b/src/Sephpa.php
@@ -134,7 +134,7 @@ abstract class Sephpa
         $grpHdr->addChild('MsgId', $this->msgId);
         $grpHdr->addChild('CreDtTm', $creDtTm);
         $grpHdr->addChild('NbOfTxs', $totalNumberOfTransaction);
-        $grpHdr->addChild('CtrlSum', sprintf('%01.2f', $this->getCtrlSum()));
+        $grpHdr->addChild('CtrlSum', sprintf('%01.2F', $this->getCtrlSum()));
         $grpHdr->addChild('InitgPty')->addChild('Nm', $this->initgPty);
         
         foreach($this->paymentCollections as $paymentCollection)

--- a/src/payment-collections/SepaCreditTransfer00100103.php
+++ b/src/payment-collections/SepaCreditTransfer00100103.php
@@ -200,7 +200,7 @@ class SepaCreditTransfer00100103 implements SepaPaymentCollection
     private function generatePaymentXml(\SimpleXMLElement $cdtTrfTxInf, $payment, $ccy)
     {
         $cdtTrfTxInf->addChild('PmtId')->addChild('EndToEndId', $payment['pmtId']);
-        $cdtTrfTxInf->addChild('Amt')->addChild('InstdAmt', $payment['instdAmt'])
+        $cdtTrfTxInf->addChild('Amt')->addChild('InstdAmt', sprintf("%01.2F", $payment['instdAmt']))
                     ->addAttribute('Ccy', $ccy);
         if( !empty( $payment['bic'] ) )
             $cdtTrfTxInf->addChild('CdtrAgt')->addChild('FinInstnId')

--- a/src/payment-collections/SepaCreditTransfer00100103.php
+++ b/src/payment-collections/SepaCreditTransfer00100103.php
@@ -156,7 +156,7 @@ class SepaCreditTransfer00100103 implements SepaPaymentCollection
         if( !empty( $this->transferInfo['btchBookg'] ) )
             $pmtInf->addChild('BtchBookg', $this->transferInfo['btchBookg']);
         $pmtInf->addChild('NbOfTxs', $this->getNumberOfTransactions());
-        $pmtInf->addChild('CtrlSum', sprintf("%01.2f", $this->getCtrlSum()));
+        $pmtInf->addChild('CtrlSum', sprintf("%01.2F", $this->getCtrlSum()));
 
         $pmtTpInf = $pmtInf->addChild('PmtTpInf');
         $pmtTpInf->addChild('InstrPrty', 'NORM');

--- a/src/payment-collections/SepaCreditTransfer00100203.php
+++ b/src/payment-collections/SepaCreditTransfer00100203.php
@@ -153,7 +153,7 @@ class SepaCreditTransfer00100203 implements SepaPaymentCollection
         if( !empty( $this->transferInfo['btchBookg'] ) )
             $pmtInf->addChild('BtchBookg', $this->transferInfo['btchBookg']);
         $pmtInf->addChild('NbOfTxs', $this->getNumberOfTransactions());
-        $pmtInf->addChild('CtrlSum', sprintf('%01.2f', $this->getCtrlSum()));
+        $pmtInf->addChild('CtrlSum', sprintf('%01.2F', $this->getCtrlSum()));
 
         $pmtTpInf = $pmtInf->addChild('PmtTpInf');
         $pmtTpInf->addChild('InstrPrty', 'NORM');

--- a/src/payment-collections/SepaCreditTransfer00100303.php
+++ b/src/payment-collections/SepaCreditTransfer00100303.php
@@ -156,7 +156,7 @@ class SepaCreditTransfer00100303 implements SepaPaymentCollection
         if( !empty( $this->transferInfo['btchBookg'] ) )
             $pmtInf->addChild('BtchBookg', $this->transferInfo['btchBookg']);
         $pmtInf->addChild('NbOfTxs', $this->getNumberOfTransactions());
-        $pmtInf->addChild('CtrlSum', sprintf("%01.2f", $this->getCtrlSum()));
+        $pmtInf->addChild('CtrlSum', sprintf("%01.2F", $this->getCtrlSum()));
 
         $pmtTpInf = $pmtInf->addChild('PmtTpInf');
         $pmtTpInf->addChild('InstrPrty', 'NORM');

--- a/src/payment-collections/SepaDirectDebit00800102.php
+++ b/src/payment-collections/SepaDirectDebit00800102.php
@@ -182,7 +182,7 @@ class SepaDirectDebit00800102 implements SepaPaymentCollection
         if( !empty( $this->debitInfo['btchBookg'] ) )
             $pmtInf->addChild('BtchBookg', $this->debitInfo['btchBookg']);
         $pmtInf->addChild('NbOfTxs', $this->getNumberOfTransactions());
-        $pmtInf->addChild('CtrlSum', sprintf('%01.2f', $this->getCtrlSum()));
+        $pmtInf->addChild('CtrlSum', sprintf('%01.2F', $this->getCtrlSum()));
 
         $pmtTpInf = $pmtInf->addChild('PmtTpInf');
         $pmtTpInf->addChild('SvcLvl')->addChild('Cd', 'SEPA');
@@ -233,7 +233,7 @@ class SepaDirectDebit00800102 implements SepaPaymentCollection
     private function generatePaymentXml(\SimpleXMLElement $drctDbtTxInf, $payment, $ccy)
     {
         $drctDbtTxInf->addChild('PmtId')->addChild('EndToEndId', $payment['pmtId']);
-        $drctDbtTxInf->addChild('InstdAmt', sprintf('%01.2f', $payment['instdAmt']))
+        $drctDbtTxInf->addChild('InstdAmt', sprintf('%01.2F', $payment['instdAmt']))
                      ->addAttribute('Ccy', $ccy);
 
         $mndtRltdInf = $drctDbtTxInf->addChild('DrctDbtTx')->addChild('MndtRltdInf');

--- a/src/payment-collections/SepaDirectDebit00800202.php
+++ b/src/payment-collections/SepaDirectDebit00800202.php
@@ -164,7 +164,7 @@ class SepaDirectDebit00800202 implements SepaPaymentCollection
         if( !empty( $this->debitInfo['btchBookg'] ) )
             $pmtInf->addChild('BtchBookg', $this->debitInfo['btchBookg']);
         $pmtInf->addChild('NbOfTxs', $this->getNumberOfTransactions());
-        $pmtInf->addChild('CtrlSum', sprintf('%01.2f', $this->getCtrlSum()));
+        $pmtInf->addChild('CtrlSum', sprintf('%01.2F', $this->getCtrlSum()));
 
         $pmtTpInf = $pmtInf->addChild('PmtTpInf');
         $pmtTpInf->addChild('SvcLvl')->addChild('Cd', 'SEPA');
@@ -211,7 +211,7 @@ class SepaDirectDebit00800202 implements SepaPaymentCollection
     private function generatePaymentXml(\SimpleXMLElement $drctDbtTxInf, $payment, $ccy)
     {
         $drctDbtTxInf->addChild('PmtId')->addChild('EndToEndId', $payment['pmtId']);
-        $drctDbtTxInf->addChild('InstdAmt', sprintf('%01.2f', $payment['instdAmt']))
+        $drctDbtTxInf->addChild('InstdAmt', sprintf('%01.2F', $payment['instdAmt']))
                      ->addAttribute('Ccy', $ccy);
 
         $mndtRltdInf = $drctDbtTxInf->addChild('DrctDbtTx')->addChild('MndtRltdInf');

--- a/src/payment-collections/SepaDirectDebit00800302.php
+++ b/src/payment-collections/SepaDirectDebit00800302.php
@@ -172,7 +172,7 @@ class SepaDirectDebit00800302 implements SepaPaymentCollection
         if( !empty( $this->debitInfo['btchBookg'] ) )
             $pmtInf->addChild('BtchBookg', $this->debitInfo['btchBookg']);
         $pmtInf->addChild('NbOfTxs', $this->getNumberOfTransactions());
-        $pmtInf->addChild('CtrlSum', sprintf('%01.2f', $this->getCtrlSum()));
+        $pmtInf->addChild('CtrlSum', sprintf('%01.2F', $this->getCtrlSum()));
 
         $pmtTpInf = $pmtInf->addChild('PmtTpInf');
         $pmtTpInf->addChild('SvcLvl')->addChild('Cd', 'SEPA');
@@ -223,7 +223,7 @@ class SepaDirectDebit00800302 implements SepaPaymentCollection
     private function generatePaymentXml(\SimpleXMLElement $drctDbtTxInf, $payment, $ccy)
     {
         $drctDbtTxInf->addChild('PmtId')->addChild('EndToEndId', $payment['pmtId']);
-        $drctDbtTxInf->addChild('InstdAmt', sprintf('%01.2f', $payment['instdAmt']))
+        $drctDbtTxInf->addChild('InstdAmt', sprintf('%01.2F', $payment['instdAmt']))
                      ->addAttribute('Ccy', $ccy);
 
         $mndtRltdInf = $drctDbtTxInf->addChild('DrctDbtTx')->addChild('MndtRltdInf');


### PR DESCRIPTION
Use non-locale aware type specifier (i.e. always use period (.) as decimal mark)
Before, if your locale was set to certain locales (for instance nl_NL), the XML output would use a decimal comma (1234,56) which is not valid.