### PR TITLE
Fix fix_SepaDirectDebit00800102 validation error

### DIFF
--- a/src/Sephpa.php
+++ b/src/Sephpa.php
@@ -174,7 +174,11 @@ abstract class Sephpa
         {
             $orgId = $initgPty->Id->addChild('OrgId');
             if(!empty($this->orgId['id']))
-                $orgId->addChild('Othr')->addChild('Id', $this->orgId['id']);
+            {
+                $initgPtyOthr = $orgId->addChild('Othr');
+                $initgPtyOthr->addChild('Id', $this->orgId['id']);
+                $initgPtyOthr->addChild('SchmeNm', '')->addChild("Prtry", "SEPA");
+            }
             if(!empty($this->orgId['bob']))
                 $orgId->addChild('BICOrBEI', $this->orgId['bob']);
         }


### PR DESCRIPTION
Fix validation error in Spanish bank:
````
Identificación SEPA del presentador incorrecta. Crríjalo y reenvíe.
No se permite identificadores SEPA del presentador extranjero. Crríjalo y reenvíe.
````

To make it work, you must initialize `SephpaDirectDebit` like this:
```php
$directDebitFile = new SephpaDirectDebit(
    $initgPty,
    $msgId,
    SephpaDirectDebit::SEPA_PAIN_008_001_02,
    array('id' => $creditorIdentifier)
);
```