### PR TITLE
Fix typos in XSD for PAIN_008_001_08

### DIFF
--- a/src/SephpaDirectDebit.php
+++ b/src/SephpaDirectDebit.php
@@ -30,7 +30,7 @@ class SephpaDirectDebit extends Sephpa
     private const INITIAL_STRING_PAIN_008_001_02_AUSTRIAN_003 = '<?xml version="1.0" encoding="UTF-8"?><Document xmlns="ISO:pain.008.001.02:APC:STUZZA:payments:003" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"></Document>';
     private const INITIAL_STRING_PAIN_008_002_02 = '<?xml version="1.0" encoding="UTF-8"?><Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.002.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.008.002.02 pain.008.002.02.xsd"></Document>';
     private const INITIAL_STRING_PAIN_008_003_02 = '<?xml version="1.0" encoding="UTF-8"?><Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02 pain.008.003.02.xsd"></Document>';
-    private const INITIAL_STRING_PAIN_008_001_08 = '<?xml version="1.0" encoding="UTF-8"?><Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.08" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02 pain.008.001.08.xsd"></Document>';
+    private const INITIAL_STRING_PAIN_008_001_08 = '<?xml version="1.0" encoding="UTF-8"?><Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.08" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.008.001.08 pain.008.001.08.xsd"></Document>';
 
     private const VERSIONS = [self::SEPA_PAIN_008_001_02              => ['class'   => '00800102',
                                                                           'initStr' => self::INITIAL_STRING_PAIN_008_001_02],


### PR DESCRIPTION
Fix incorrect schema location for pain.008.001.08 format

Fixes #46

**Problem:**
The current implementation uses an incorrect schema location reference for pain.008.001.08 format:
- **Wrong:** `urn:iso:std:iso:20022:tech:xsd:pain.008.003.02`  
- **Correct:** `urn:iso:std:iso:20022:tech:xsd:pain.008.001.08`

**Impact:**
While many applications ignore XSD validation, banking software like **SFirm** strictly validates XML schemas and rejects files with incorrect schema references, causing document processing errors.

**Changes:**
- Updated `INITIAL_STRING_PAIN_008_001_08` constant to reference the correct schema location
- Ensures consistency between XML namespace and schema location for pain.008.001.08